### PR TITLE
Adds privacy policy

### DIFF
--- a/policy_03_privacy.md
+++ b/policy_03_privacy.md
@@ -1,0 +1,63 @@
+# Dogecoin Foundation - Very Privacy
+
+## Introduction
+
+Much like our Code of Shibes, this Privacy Policy reflects our commitment to the Four Pillars of the Dogecoin Manifesto: being **Personable**, **Useful**, **Reliable**, and **Welcoming**. We believe in transparency about how we handle your information, because good shibes respect good shibes.
+
+## Scope
+
+This Privacy Policy applies to all visitors and users of Dogecoin Foundation digital properties, including our websites, mobile applications, and online services. If you access or use any Dogecoin Foundation web or app properties, this policy describes how we handle the information collected during your visit.
+
+## What Information We Collect (and Why)
+
+### The Basics
+
+When you interact with Dogecoin Foundation spaces (our website, events, or community platforms), we collect only what's needed to keep things running:
+
+- **Contact information** (like email addresses) when you sign up for updates or reach out to us
+- **Technical details** (browser type, device info) that help us make our website work better for everyone
+- **Cookies and similar technologies** that remember your preferences and help us understand how our services are used
+
+### Why We Need This
+
+We're collecting this information to:
+- Keep our community spaces functioning properly
+- Respond when you reach out to us (wow, such communication!)
+- Make improvements based on how shibes use our services
+- Send you important updates about Dogecoin (but only if you want them!)
+
+## How We Handle Your Data (Much Careful)
+
+### No Selling, No Sharing
+
+We **DO NOT** sell or provide your personal information to third parties (inclusive of any and all listed sponsor of events/functions/initiatives) for marketing purposes. Your data stays within the Dogecoin Foundation except when:
+
+- We need trusted service providers to help run our platforms (they're bound by the same rules)
+- We're legally required to share information (we'll only share what we must)
+- You've specifically asked us to share your information
+
+### Security (Very Protection!)
+
+We implement reasonable security measures to protect your data, though no system is 100% secure. We treat your information with the same care we'd want for our own.
+
+## Your Rights as a Shibe
+
+As a valued community member, you have the right to:
+- See what information we have about you
+- Ask us to update or delete your information
+- Opt out of communications
+- Ask questions about how we're handling your data
+
+## Cookies (Tasty for Browsers, Not Dogs)
+
+Our website uses cookies to enhance your experience. You can manage cookie settings through your browser, though some features might not work as well without them.
+
+## Changes to This Policy
+
+We may update this policy as our practices evolve. We'll notify the community of significant changes through our usual communication channels.
+
+## Contact Us
+
+If you have questions about your privacy or this policy, please reach out to us at privacy@dogecoin.org
+
+***Thank you for being part of our community - together we'll keep Dogecoin friendly, safe, and respectful of everyone's privacy!***


### PR DESCRIPTION
**Context**: 
With the 2025 hackathon registration page going live imminently, inevitable raised the point that as it collect registration data, the site should link to a privacy policy for transparent and clear stance on whats collected, why and its use.

**Proposal:**
I've drafted this policy taking cues from the code of conduct.  My intent is for people who view fdn websites and view this policy to understand:

**Crux of the policy**:
1. we collect the bare minimum to make these sites function.  (ie, cookies are for remembering preferences)
2. we have no interest in selling or sharing your data.
3. our events often have sponsors. we don't share your data with them.
4. we don't send marketing email.  we send transactional email (ie, buy a ticket, receive the ticket by email)
5. you can reach a human and get help re privacy via privacy@dogecoin.org

Once this PR has had review, I'm suggesting we link to this policy from the upcoming hackathon website and from the foundation home page.

Be gentle, I am not a lawyer.  
I just want to state clearly that our objective is to uphold shibe's right to privacy.